### PR TITLE
feature: ComIntfdObjects may be explicitly free'd

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 mode: ContinuousDeployment
 increment: None
-next-version: 1.1.1
+next-version: 1.2.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/src/Deltics.InterfacedObjects.ComInterfacedObject.pas
+++ b/src/Deltics.InterfacedObjects.ComInterfacedObject.pas
@@ -107,7 +107,11 @@ implementation
   { - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - }
   procedure TComInterfacedObject.Free;
   begin
-    raise EInvalidPointer.Create('You must not explicitly free a COM interfaced object (or class derived from it).  Lifecycle of these objects is determined by reference counting.');
+    if (fReferenceCount > 0) then
+      raise EInvalidPointer.Create('You must not explicitly free a COM interfaced object (or class '
+                                 + 'derived from it) where interface references have been '
+                                 + 'obtained.  The lifecycle of these objects is determined by '
+                                 + 'reference counting.');
   end;
 
 

--- a/src/Deltics.InterfacedObjects.ComInterfacedObject.pas
+++ b/src/Deltics.InterfacedObjects.ComInterfacedObject.pas
@@ -112,6 +112,8 @@ implementation
                                  + 'derived from it) where interface references have been '
                                  + 'obtained.  The lifecycle of these objects is determined by '
                                  + 'reference counting.');
+
+    Destroy;
   end;
 
 

--- a/src/Deltics.InterfacedObjects.InterfacedObjectList.pas
+++ b/src/Deltics.InterfacedObjects.InterfacedObjectList.pas
@@ -107,7 +107,7 @@ implementation
     onDestroy: IOn_Destroy;
   begin
     if (ReferenceCount = 0) then
-      raise EInvalidOperation.Create('You appear to be using a reference counted object list via an object reference.  Reference counted lists MUST be used via an interface reference to avoid errors arising from the internal On_Destroy mechanism');
+      raise EInvalidOperation.Create('You appear to be using a reference counted object list via an object reference.  Reference counted object lists MUST be used via an interface reference to avoid errors arising from the internal On_Destroy mechanism');
 
     item := TListItem.Create;
     item.ItemObject := aObject;

--- a/tests/Test.ComInterfacedObject.pas
+++ b/tests/Test.ComInterfacedObject.pas
@@ -71,7 +71,7 @@ implementation
     intf: IUnknown;
     iod: IOn_Destroy;
   begin
-    Test.RaisedException(EInvalidPointer);
+    Test.RaisesException(EInvalidPointer);
 
     sut := TComInterfacedObject.Create;
 

--- a/tests/test.dproj
+++ b/tests/test.dproj
@@ -47,7 +47,7 @@
     <PropertyGroup Condition="'$(Base)'!=''">
         <DCC_RemoteDebug>true</DCC_RemoteDebug>
         <DCC_MapFile>3</DCC_MapFile>
-        <DCC_Define>debug_delticsinterfaces;debug_delticsinterfacedobjects;$(DCC_Define)</DCC_Define>
+        <DCC_Define>debug_delticsinterfacedobjects;FullDebugMode;debug_delticssmoketest;$(DCC_Define)</DCC_Define>
         <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
         <Manifest_File>None</Manifest_File>
         <VerInfo_Locale>1033</VerInfo_Locale>


### PR DESCRIPTION
Allows for the scenario where a ComInterfacedObject has been allocated without any interface reference having been taken, allowing such objects to be explicitly free'd.